### PR TITLE
add freetype dependency

### DIFF
--- a/depends/common/freetype/CMakeLists.txt
+++ b/depends/common/freetype/CMakeLists.txt
@@ -1,0 +1,15 @@
+project(freetype)
+
+cmake_minimum_required(VERSION 2.8)
+
+include(ExternalProject)
+externalproject_add(freetype
+                    SOURCE_DIR ${CMAKE_SOURCE_DIR}
+                    UPDATE_COMMAND ""
+                    CONFIGURE_COMMAND <SOURCE_DIR>/configure 
+                      --prefix=${OUTPUT_DIR}
+                      --disable-shared
+                    INSTALL_COMMAND ""
+                    BUILD_IN_SOURCE 1)
+                  
+install(CODE "execute_process(COMMAND make install WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")

--- a/depends/common/freetype/freetype.txt
+++ b/depends/common/freetype/freetype.txt
@@ -1,0 +1,1 @@
+freetype http://mirrors.xbmc.org/build-deps/sources/freetype-2.4.7.tar.bz2

--- a/depends/common/ftgl/deps.txt
+++ b/depends/common/ftgl/deps.txt
@@ -1,0 +1,1 @@
+freetype


### PR DESCRIPTION
adds a basic freetype definition.

note that there are some extra stuff in the tools/depends definition that isn't covered by this. might be some of them are crucial.
